### PR TITLE
Disable flipper in BuildProject

### DIFF
--- a/BuildProject/ios/Podfile
+++ b/BuildProject/ios/Podfile
@@ -20,12 +20,6 @@ target 'BuildProject' do
     # Pods for testing
   end
 
-  # Enables Flipper.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable the next line.
-  use_flipper!()
-
   post_install do |installer|
     react_native_post_install(installer)
   end


### PR DESCRIPTION
Fixes react-native-metrics/BuildProject/ios/Pods/Headers/Public/Flipper-Folly/folly/portability/Time.h:52:17: error: typedef redefinition with different types ('uint8_t' (aka 'unsigned char') vs 'enum clockid_t')