### PR TITLE
Update android-metrics-sdk dependency to 0.1.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,5 +131,5 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   // Expose transitive dependency for RN consumers
-  api "ai.promoted:android-metrics-sdk:0.1.3"
+  api "ai.promoted:android-metrics-sdk:0.1.4"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,5 +131,5 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   // Expose transitive dependency for RN consumers
-  api "ai.promoted:android-metrics-sdk:0.1.4"
+  api "ai.promoted:android-metrics-sdk:0.1.5"
 }

--- a/android/src/main/java/ai/promoted/PromotedMetricsModule.kt
+++ b/android/src/main/java/ai/promoted/PromotedMetricsModule.kt
@@ -170,12 +170,11 @@ class PromotedMetricsModule(
   @ReactMethod
   @Suppress("Unused")
   fun getCurrentOrPendingAncestorIds(promise: Promise) {
-    val currentSessionInfo = PromotedAi.currentSessionInfo
     promise.resolve(
       Arguments.createMap().apply {
-        putString("logUserId", currentSessionInfo.logUserId)
-        putString("sessionId", currentSessionInfo.sessionId)
-        putString("viewId", currentSessionInfo.viewId)
+        putString("logUserId", PromotedAi.logUserId)
+        putString("sessionId", PromotedAi.sessionId)
+        putString("viewId", PromotedAi.viewId)
       }
     )
   }


### PR DESCRIPTION
- android-metrics-sdk 0.1.5 has support for our recent AncestorId changes
- Also fixes a crash on startup due to DI issues
- The new dependency requires a change in PromotedMetricsModule