### PR TITLE
Update ios-metrics-sdk dependency to 0.4.5

### DIFF
--- a/react-native-metrics.podspec
+++ b/react-native-metrics.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "PromotedAIMetricsSDK", "~> 0.4.4"
+  s.dependency "PromotedAIMetricsSDK", "~> 0.4.5"
 
   # If the app pulls in PromotedAIMetricsSDK/FirebaseAnalytics,
   # then we need to pull this in too. If the app doesn't pull in


### PR DESCRIPTION
This includes support for `ImpressionSourceType`.