### PR TITLE
Fix state getter on newer versions of react-navigation

### DIFF
--- a/src/ViewTracker.tsx
+++ b/src/ViewTracker.tsx
@@ -87,7 +87,11 @@ var mostRecentlyLoggedAutoViewState: AutoViewState = {
 var routeKeyToAutoViewId = new LRUCache()
 
 function getStateReactNavigation5OrLater(navigation) {
-  const state = navigation.getState()
+  const state = (
+    typeof(navigation.getState) == 'function' ?
+    navigation.getState() :
+    navigation.dangerouslyGetState()
+  )
   const route = state.routes[state.index]
   return {
     routeName: route.name,


### PR DESCRIPTION
Although `dangerouslyGetState` sounds ominous, it's the only way to get state in react-navigation 5. `getState` is only available in react-navigation 6+.