### PR TITLE
Do not automatically log actions from `CollectionTracker`

### DIFF
--- a/src/CollectionTracker.tsx
+++ b/src/CollectionTracker.tsx
@@ -34,8 +34,8 @@ const { PromotedMetrics } = NativeModules
  */
 export interface CollectionTrackerProps {
   forwardedRef?: React.Ref<any>
-  onViewableItemsChanged?: (arg: any) => void
-  renderItem: (arg: any) => any
+  onViewableItemsChanged?: (args: any) => void
+  renderItem: (args: any) => any
   viewabilityConfig?: any
   viewabilityConfigCallbackPairs?: Array<any>
 }

--- a/src/CollectionTracker.tsx
+++ b/src/CollectionTracker.tsx
@@ -325,6 +325,12 @@ export function CollectionTracker<
             name: null,
           })
         }
+        const touchMoveHandler = () => {
+          setActionState({
+            actionType: null,
+            name: null,
+          })
+        }
         const touchEndHandler = () => {
           // If an accessory event handler has set `actionType` to
           // `null`, do not log.
@@ -350,6 +356,7 @@ export function CollectionTracker<
         return (
           <View
             onTouchStart={touchStartHandler}
+            onTouchMove={touchMoveHandler}
             onTouchEnd={touchEndHandler}
             pointerEvents={'box-none'}
           >

--- a/src/CollectionTracker.tsx
+++ b/src/CollectionTracker.tsx
@@ -145,14 +145,14 @@ const CollectionTrackerContext = React.createContext({
  *
  * @returns setter function for `actionType` and `name`
  */
-export function useCollectionActionState() {
+export function useCollectionActionLogger() {
   const context = React.useContext(CollectionTrackerContext)
   return {
-    setActionState: ({
+    logCollectionAction: ({
       actionType,
       name = '',
     }: CollectionActionState) => {
-      context.setActionState({ actionType, name })
+      context.logCollectionAction({ actionType, name })
     }
   }
 }

--- a/src/CollectionTracker.tsx
+++ b/src/CollectionTracker.tsx
@@ -319,11 +319,16 @@ export function CollectionTracker<
       // Callback to log actions associated with this collection.
       const autoViewStateRef = useAutoViewState()
       const itemRef = React.useRef({})
-      const logCollectionAction = React.useCallback((actionState) => {
+      const logCollectionAction = React.useCallback((
+        args: CollectionActionState = {
+          actionType: ActionType.Navigate,
+          name: null,
+        }
+      ) => {
         const {
           name,
           actionType,
-        } = actionState
+        } = args
         const {
           autoViewId,
           hasSuperimposedViews,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ export {
 export {
   CollectionActionState,
   CollectionTracker,
-  useCollectionActionState,
+  useCollectionActionLogger,
   useCollectionTracker,
 } from './CollectionTracker'
 


### PR DESCRIPTION
Remove the automatic navigate action tracking for list items in `CollectionTracker`. This approach was problematic and not worth the small code savings in client integration.

The problem was that different platforms and versions of React Native behave inconsistently with respect to tap event handling. As a result, we were receiving taps to log actions when the list was scrolled, but no navigate action occurred.

The new approach introduces a function `logCollectionAction()`, and requires client to explicitly call this function to log navigate actions.