### PR TITLE
Lower react (16.13.1) and react-native (0.64.2) min versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promotedai/react-native-metrics",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Promoted metrics logging library for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -29,7 +29,7 @@
     "android"
   ],
   "repository": "https://github.com/promotedai/react-native-metrics",
-  "author": "Yu-Hong Wang <yu-hong@promoted.ai> (https://github.com/rockapot)",
+  "author": "Yuhong Wang <yuhong@promoted.ai> (https://github.com/rockapot)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/promotedai/react-native-metrics/issues"

--- a/package.json
+++ b/package.json
@@ -55,14 +55,14 @@
   },
   "peerDependencies": {
     "@react-navigation/core": ">= 5.0.0",
-    "react": ">= 16.14.0",
-    "react-native": ">= 0.64.2",
+    "react": ">= 16.13.1",
+    "react-native": ">= 0.63.4",
     "react-native-uuid": ">= 1.0.0"
   },
   "devDependencies": {
     "@react-navigation/core": ">= 5.0.0",
-    "react": ">= 16.14.0",
-    "react-native": ">= 0.64.2",
+    "react": ">= 16.13.1",
+    "react-native": ">= 0.63.4",
     "react-native-builder-bob": "0.18.1",
     "react-native-uuid": ">= 1.0.0",
     "typescript": "^4.3.2"


### PR DESCRIPTION
This removes the need to run `npm install` with the `--force` flag for partners using these versions of react/react-native.