### PR TITLE
Import `useNavigation` from `@react-navigation/native` instead of `@react-navigation/core`

### DIFF
--- a/BuildProject/package.json
+++ b/BuildProject/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@promotedai/react-native-metrics": "file:../",
-    "@react-navigation/core": "^6.0.2",
+    "@react-navigation/native": "^6.0.2",
     "@react-navigation/native-stack": "^6.0.2",
     "appium": "^1.21.0",
     "appium-doctor": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "peerDependencies": {
-    "@react-navigation/core": ">= 5.0.0",
+    "@react-navigation/native": ">= 5.0.0",
     "react": ">= 16.13.1",
     "react-native": ">= 0.63.4",
     "react-native-uuid": ">= 1.0.0"

--- a/src/ViewTracker.tsx
+++ b/src/ViewTracker.tsx
@@ -3,13 +3,15 @@
 // react-navigation-hooks.
 // Since @r-n/core is listed as a dependency in package.json,
 // it's fine to have this outer require() without a try/catch.
-let useNavigation = require('@react-navigation/core').useNavigation
-let useFocusEffect = require('@react-navigation/core').useFocusEffect
+let navigation5OrLater = require('@react-navigation/native')
+let useNavigation = navigation5OrLater?.useNavigation
+let useFocusEffect = navigation5OrLater?.useFocusEffect
 let isReactNavigation5OrLater = true
 if (!useNavigation || !useFocusEffect) {
   try {
-    useNavigation = require('react-navigation-hooks').useNavigation
-    useFocusEffect = require('react-navigation-hooks').useFocusEffect
+    let navigation4OrEarlier = require('react-navigation-hooks')
+    useNavigation = navigation4OrEarlier?.useNavigation
+    useFocusEffect = navigation4OrEarlier?.useFocusEffect
     isReactNavigation5OrLater = false
   } catch (e) {
     if (process.env.NODE_ENV !== 'production') {
@@ -24,7 +26,7 @@ if (!useNavigation || !useFocusEffect) {
     if (process.env.NODE_ENV !== 'production') {
       console.error(
         'Could not import navigation hooks from either ' +
-        '@react-navigation/core or react-navigation-hooks. ' +
+        '@react-navigation/native or react-navigation-hooks. ' +
         'View tracking will be disabled and Promoted ' +
         'integration may be degraded.'
       )
@@ -35,8 +37,7 @@ if (!useNavigation || !useFocusEffect) {
         key: '',
       },
     })
-    // @ts-ignore (TS6133: 'any' is declared but its value is never read)
-    useFocusEffect = (any) => {}
+    useFocusEffect = (_: any) => {}
     isReactNavigation5OrLater = false
   }
 }


### PR DESCRIPTION
Fixes an import not found for clients who use a `@react-navigation/native`. From a GitHub search, it appears that `native` is a much more frequently-used dependency than `core`.