### PR TITLE
feat: export `useImpressionTracker`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,3 +45,7 @@ export {
   useUnscopedMetricsLogger,
   withMetricsLogger,
 } from './MetricsLogger'
+
+export {
+  useImpressionTracker,
+} from './useImpressionTracker'


### PR DESCRIPTION
PRO-4932

One client wants to use the SDK.  `useImpressionTracker` is mentioned in the top-level README but not exported.

TESTING=None.  I'll wait for GitHub Actions to run.