### PR TITLE
fix: android build

### DIFF
--- a/BuildProject/android/app/build.gradle
+++ b/BuildProject/android/app/build.gradle
@@ -71,6 +71,17 @@ android {
 
         }
     }
+
+    packagingOptions {
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libfbjni.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libfbjni.so'
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86/libfbjni.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/x86_64/libfbjni.so'
+    }
 }
 
 dependencies {

--- a/BuildProject/android/build.gradle
+++ b/BuildProject/android/build.gradle
@@ -1,6 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['PromotedMetrics_kotlinVersion']
+
     ext {
         buildToolsVersion = "29.0.3"
         minSdkVersion = 21
@@ -16,6 +18,7 @@ buildscript {
         classpath("com.android.tools.build:gradle:4.1.0")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/BuildProject/android/gradle.properties
+++ b/BuildProject/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
@@ -26,3 +26,5 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.75.1
+
+PromotedMetrics_kotlinVersion=1.7.10

--- a/BuildProject/android/gradlew
+++ b/BuildProject/android/gradlew
@@ -44,7 +44,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS='"-Xmx1024m" "-Xms256m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/BuildProject/android/gradlew.bat
+++ b/BuildProject/android/gradlew.bat
@@ -33,7 +33,7 @@ set APP_HOME=%DIRNAME%
 for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+set DEFAULT_JVM_OPTS="-Xmx1024m" "-Xms256m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome

--- a/BuildProject/package-lock.json
+++ b/BuildProject/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "BuildProject",
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
@@ -36,7 +37,7 @@
     },
     "..": {
       "name": "@promotedai/react-native-metrics",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@react-navigation/core": ">= 5.0.0",


### PR DESCRIPTION
Splitting from [PR#94](https://github.com/promotedai/react-native-metrics/pull/94).

It looks like the GitHub Action broke sometime over the past year.

Includes:
- Changes gha to run on push to any branch.
- Switches to use open jdk.
- Increases memory for java build.

TESTING=Ran locally and in GHA.